### PR TITLE
Support Gateway API

### DIFF
--- a/src/components/connected-button/connected-button.tsx
+++ b/src/components/connected-button/connected-button.tsx
@@ -9,6 +9,8 @@ export class ConnectedButton {
   @State() success?: string;
   @State() badRequest?: string;
   @State() unauthenticated?: string;
+  @State() planCost: string;
+
   connection: Connection;
   async componentWillLoad() {
     await customElements.whenDefined('mui-core');
@@ -40,6 +42,15 @@ export class ConnectedButton {
     this.unauthenticated = JSON.stringify(response, null, 2);
   };
 
+  getPlanCost = async () => {
+    const planID = '235exy25wvzpxj52p87bh87gbnj4y';
+    const selection = { backups: 1, instance_class: 'db.t2.micro', redundancy: false, storage: 5 };
+    const response = await this.connection.gateway.post(`/id/plan/${planID}/cost`, {
+      features: selection,
+    });
+    this.planCost = JSON.stringify(response);
+  };
+
   render() {
     return (
       <div>
@@ -67,6 +78,15 @@ export class ConnectedButton {
         {this.unauthenticated && (
           <p>
             Response: <pre>{this.unauthenticated}</pre>
+          </p>
+        )}
+        <hr />
+        <button type="button" onClick={this.getPlanCost}>
+          Send (plan cost)
+        </button>
+        {this.planCost && (
+          <p>
+            Response: <pre>{this.planCost}</pre>
           </p>
         )}
       </div>

--- a/src/v0/gateway.ts
+++ b/src/v0/gateway.ts
@@ -1,0 +1,92 @@
+import { ManifoldError, ErrorType } from './ManifoldError';
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+interface CreateGatewayFetch {
+  gatewayUrl?: () => string;
+  element: HTMLElement;
+  version: string;
+  retries?: number;
+}
+
+export interface Gateway {
+  post: <Body extends {}, Return>(path: string, body: Body) => Promise<Return>;
+}
+
+export function createGateway({
+  element,
+  version,
+  gatewayUrl = () => 'https://api.manifold.co/v1',
+  retries = 3,
+}: CreateGatewayFetch): Gateway {
+  async function post<Body extends {}, Return>(
+    path: string,
+    body: Body,
+    attempts: number
+  ): Promise<Return> {
+    const options: RequestInit = {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: {
+        Connection: 'keep-alive',
+        'Content-type': 'application/json',
+        'x-mui-component': `${element.tagName}@${version}`,
+        'x-manifold-mui-core-version': '<@NPM_PACKAGE_VERSION@>',
+      },
+    };
+    const canRetry = attempts < retries;
+
+    // Send Request
+    let response: Response;
+    try {
+      response = await fetch(`${gatewayUrl()}${path}`, options);
+    } catch (e) {
+      // Retry
+      if (canRetry) {
+        await wait(attempts ** 2 * 1000);
+        return post(path, body, attempts + 1);
+      }
+      return Promise.reject(new ManifoldError({ type: ErrorType.NetworkError }));
+    }
+
+    // Immediately reject on internal server error.
+    const internalServerError = response.status > 500;
+    if (internalServerError) {
+      return Promise.reject(
+        new ManifoldError({ type: ErrorType.ServerError, message: response.statusText })
+      );
+    }
+
+    // Retry on other server errors.
+    const serverError = response.status > 500;
+    if (serverError) {
+      if (canRetry) {
+        await wait(attempts ** 2 * 1000);
+        return post(path, body, attempts + 1);
+      }
+      return Promise.reject(
+        new ManifoldError({ type: ErrorType.ServerError, message: response.statusText })
+      );
+    }
+
+    // Reauthenticate and retry on auth errors.
+    const authError = response.status === 401;
+    if (authError && canRetry) {
+      // TODO retry auth
+      return Promise.reject(
+        new ManifoldError({ type: ErrorType.AuthorizationError, message: response.statusText })
+      );
+    }
+
+    const responseBody: Return = await response.json();
+    return responseBody;
+  }
+
+  return {
+    post<Body extends {}, Return>(path: string, body: Body) {
+      return post<Body, Return>(path, body, 0);
+    },
+  };
+}

--- a/src/v0/gateway.ts
+++ b/src/v0/gateway.ts
@@ -6,8 +6,6 @@ function wait(ms) {
 
 interface CreateGatewayFetch {
   gatewayUrl?: () => string;
-  element: HTMLElement;
-  version: string;
   retries?: number;
 }
 
@@ -16,8 +14,6 @@ export interface Gateway {
 }
 
 export function createGateway({
-  element,
-  version,
   gatewayUrl = () => 'https://api.manifold.co/v1',
   retries = 3,
 }: CreateGatewayFetch): Gateway {
@@ -32,8 +28,6 @@ export function createGateway({
       headers: {
         Connection: 'keep-alive',
         'Content-type': 'application/json',
-        'x-mui-component': `${element.tagName}@${version}`,
-        'x-manifold-mui-core-version': '<@NPM_PACKAGE_VERSION@>',
       },
     };
     const canRetry = attempts < retries;

--- a/src/v0/gateway.ts
+++ b/src/v0/gateway.ts
@@ -14,8 +14,8 @@ export interface Gateway {
 }
 
 export function createGateway({
-  gatewayUrl = () => 'https://api.manifold.co/v1',
   retries = 3,
+  gatewayUrl = () => 'https://api.manifold.co/v1',
 }: CreateGatewayFetch): Gateway {
   async function post<Body extends {}, Return>(
     path: string,
@@ -46,7 +46,7 @@ export function createGateway({
     }
 
     // Immediately reject on internal server error.
-    const internalServerError = response.status > 500;
+    const internalServerError = response.status === 500;
     if (internalServerError) {
       return Promise.reject(
         new ManifoldError({ type: ErrorType.ServerError, message: response.statusText })

--- a/src/v0/graphqlFetch.ts
+++ b/src/v0/graphqlFetch.ts
@@ -98,7 +98,7 @@ export function createGraphqlFetch({
     }
 
     // Immediately reject on internal server error.
-    const internalServerError = response.status > 500;
+    const internalServerError = response.status === 500;
     if (internalServerError) {
       return Promise.reject(
         new ManifoldError({ type: ErrorType.ServerError, message: response.statusText })

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -23,8 +23,6 @@ const connection = (options: {
 
   return {
     gateway: createGateway({
-      element,
-      version: componentVersion,
       gatewayUrl: () =>
         env === 'stage' ? 'https://api.stage.manifold.co/v1' : 'https://api.manifold.co/v1',
     }),

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -23,6 +23,7 @@ const connection = (options: {
 
   return {
     gateway: createGateway({
+      retries: 3,
       gatewayUrl: () =>
         env === 'stage' ? 'https://api.stage.manifold.co/v1' : 'https://api.manifold.co/v1',
     }),

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -1,4 +1,5 @@
 import { createGraphqlFetch, GraphqlFetch } from './graphqlFetch';
+import { createGateway, Gateway } from './gateway';
 
 // TODO add real tracking
 const track = data => {
@@ -8,6 +9,7 @@ const track = data => {
 
 export interface Connection {
   graphqlFetch: GraphqlFetch;
+  gateway: Gateway;
   track: (event: string) => void;
 }
 
@@ -20,6 +22,12 @@ const connection = (options: {
   const { componentVersion, element, env, clientId } = options;
 
   return {
+    gateway: createGateway({
+      element,
+      version: componentVersion,
+      gatewayUrl: () =>
+        env === 'stage' ? 'https://api.stage.manifold.co/v1' : 'https://api.manifold.co/v1',
+    }),
     graphqlFetch: createGraphqlFetch({
       element,
       version: componentVersion,

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -23,7 +23,6 @@ const connection = (options: {
 
   return {
     gateway: createGateway({
-      retries: 3,
       gatewayUrl: () =>
         env === 'stage' ? 'https://api.stage.manifold.co/v1' : 'https://api.manifold.co/v1',
     }),


### PR DESCRIPTION
This supports the ability to make a `POST` to the Gateway API. This should be needed temporarily so that squad-e can use the plan cost API in the plan matrix component.

## Why so specific?

The plan matrix only needs REST for one thing: making a POST to Gateway. We ultimately want everything on GraphQL, so rather than support any possible REST call, I thought it made sense to only expose what was necessary and also make it easier to use. Feedback welcome.

## For my next trick...

We'll do a beta release of this and test it out in plan matrix.