### PR TITLE
Allow any payload for the analytics click event

### DIFF
--- a/src/v0/analytics.ts
+++ b/src/v0/analytics.ts
@@ -10,6 +10,10 @@ interface SharedProperties {
   description?: string;
 }
 
+interface Payload {
+  [k: string]: string | number | boolean | Payload;
+}
+
 /**
  *  Based on `name`, what data should be sent?
  */
@@ -48,9 +52,7 @@ export type EventTypes =
     }
   | {
       name: 'click';
-      properties: {
-        planId: string;
-      };
+      properties: Payload;
     };
 
 export type EventEvent = {


### PR DESCRIPTION
Analytics type definitions had been previously copied over from plan-table, and this was done somewhat carelessly to the effect of only allowing a `planId` for the `click` event.

This PR makes the properties for the click event generic. It now allows nested objects where all values are either strings, numbers, booleans, or objects.