### PR TITLE
Add a header to get sample data when in preview mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -487,9 +487,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.25",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.25.tgz",
-      "integrity": "sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
       "dev": true,
       "requires": {
         "jest-diff": "^24.3.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@manifoldco/eslint-plugin-stencil": "^0.4.1",
     "@stencil/core": "^1.8.4",
     "@stencil/react-output-target": "0.0.6",
-    "@types/jest": "24.0.25",
+    "@types/jest": "24.9.1",
     "@types/node": "^13.7.0",
     "@types/puppeteer": "2.0.1",
     "@typescript-eslint/eslint-plugin": "^1.13.0",

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,6 +3,7 @@ import connection, { Connection as Connection_v0 } from './v0';
 interface InitOptions {
   authType?: 'manual' | 'oauth';
   env?: 'local' | 'stage' | 'prod';
+  preview?: boolean;
   getAuthToken: () => string | undefined;
   clearAuthToken: () => void;
   clientId?: string;
@@ -22,6 +23,7 @@ export function initialize(options: InitOptions): Connection {
     clientId,
     getAuthToken,
     clearAuthToken,
+    preview = false,
   } = options;
 
   switch (version) {
@@ -34,6 +36,7 @@ export function initialize(options: InitOptions): Connection {
         clientId,
         getAuthToken,
         clearAuthToken,
+        preview,
       });
     default:
       throw new Error(

--- a/src/v0/graphqlFetch.ts
+++ b/src/v0/graphqlFetch.ts
@@ -28,6 +28,7 @@ interface CreateGraphqlFetch {
   endpoint?: () => string;
   getAuthToken: () => string | undefined;
   clearAuthToken: () => void;
+  preview?: boolean;
   clientId?: string;
   element: HTMLElement;
   version: string;
@@ -75,6 +76,7 @@ export function createGraphqlFetch({
   clientId,
   analytics,
   waitTime = 15000,
+  preview,
 }: CreateGraphqlFetch): GraphqlFetch {
   async function graphqlFetch<T>(
     args: GraphqlRequest,
@@ -99,6 +101,14 @@ export function createGraphqlFetch({
 
     if (clientId) {
       options.headers['Manifold-Client-ID'] = clientId;
+    }
+
+    if (preview) {
+      if (token) {
+        console.error('Preview mode cannot be used with an auth token');
+      } else {
+        options.headers['X-Manifold-Sample'] = 'Platform';
+      }
     }
 
     if (token) {

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -16,10 +16,19 @@ const connection = (options: {
   element: HTMLElement;
   componentVersion: string;
   clientId?: string;
+  preview?: boolean;
   getAuthToken: () => string | undefined;
   clearAuthToken: () => void;
 }): Connection => {
-  const { componentVersion, element, env, clientId, getAuthToken, clearAuthToken } = options;
+  const {
+    componentVersion,
+    element,
+    env,
+    clientId,
+    getAuthToken,
+    clearAuthToken,
+    preview,
+  } = options;
 
   const analytics = createAnalytics({ env, element, componentVersion, clientId });
 
@@ -46,6 +55,7 @@ const connection = (options: {
       clearAuthToken,
       clientId,
       analytics,
+      preview,
       endpoint: () => {
         switch (env) {
           case 'stage':


### PR DESCRIPTION
This adds a mechanism to retrieve sample data ([as documented here](https://docs.manifold.co/docs/platform-invoices-76SxXWad12O4WikXlHDuf8#sample-data)) when a component initializes the connection in preview mode.