### PR TITLE
Expose ownerId to all web components

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -19,6 +19,7 @@ export namespace Components {
             componentVersion: string;
             version: number;
         }) => Promise<Connection>;
+        "ownerId"?: string;
     }
 }
 declare global {
@@ -49,6 +50,7 @@ declare namespace LocalJSX {
         "env"?: "local" | "stage" | "prod";
         "onManifold-auth-token-clear"?: (event: CustomEvent<any>) => void;
         "onManifold-auth-token-receive"?: (event: CustomEvent<string>) => void;
+        "ownerId"?: string;
     }
     interface IntrinsicElements {
         "connected-button": ConnectedButton;

--- a/src/components/manifold-init/manifold-init.tsx
+++ b/src/components/manifold-init/manifold-init.tsx
@@ -12,6 +12,7 @@ export class ManifoldInit {
   @Prop({ mutable: true }) authToken?: string;
   @Prop() authType?: 'manual' | 'oauth' = 'oauth';
   @Prop() clientId?: string;
+  @Prop() ownerId?: string;
   @Event({ eventName: 'manifold-auth-token-clear', bubbles: true }) clear: EventEmitter;
   @Event({ eventName: 'manifold-auth-token-receive', bubbles: true }) receive: EventEmitter<string>;
 
@@ -38,6 +39,7 @@ export class ManifoldInit {
     return core.initialize({
       env: this.env,
       getAuthToken: () => this.authToken,
+      getOwnerId: () => this.ownerId,
       authType: this.authType,
       version,
       componentVersion,

--- a/src/components/manifold-init/readme.md
+++ b/src/components/manifold-init/readme.md
@@ -13,6 +13,7 @@
 | `authType`  | `auth-type`  |             | `"manual" \| "oauth"`          | `'oauth'`   |
 | `clientId`  | `client-id`  |             | `string`                       | `undefined` |
 | `env`       | `env`        |             | `"local" \| "prod" \| "stage"` | `'prod'`    |
+| `ownerId`   | `owner-id`   |             | `string`                       | `undefined` |
 
 
 ## Events

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,6 +4,7 @@ interface InitOptions {
   authType?: 'manual' | 'oauth';
   env?: 'local' | 'stage' | 'prod';
   getAuthToken: () => string | undefined;
+  getOwnerId: () => string | undefined;
   clearAuthToken: () => void;
   clientId?: string;
   componentVersion: string;
@@ -22,6 +23,7 @@ export function initialize(options: InitOptions): Connection {
     clientId,
     getAuthToken,
     clearAuthToken,
+    getOwnerId,
   } = options;
 
   switch (version) {
@@ -34,6 +36,7 @@ export function initialize(options: InitOptions): Connection {
         clientId,
         getAuthToken,
         clearAuthToken,
+        getOwnerId,
       });
     default:
       throw new Error(

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -5,6 +5,7 @@ import { createGateway, Gateway } from './gateway';
 export interface Connection {
   graphqlFetch: GraphqlFetch;
   gateway: Gateway;
+  getOwnerId: () => string | undefined;
   analytics: {
     track: (e: AnalyticsEvent) => Promise<Response>;
     report: (detail: ErrorDetail) => void;
@@ -18,12 +19,22 @@ const connection = (options: {
   clientId?: string;
   getAuthToken: () => string | undefined;
   clearAuthToken: () => void;
+  getOwnerId: () => string | undefined;
 }): Connection => {
-  const { componentVersion, element, env, clientId, getAuthToken, clearAuthToken } = options;
+  const {
+    componentVersion,
+    element,
+    env,
+    clientId,
+    getAuthToken,
+    clearAuthToken,
+    getOwnerId,
+  } = options;
 
   const analytics = createAnalytics({ env, element, componentVersion, clientId });
 
   return {
+    getOwnerId,
     gateway: createGateway({
       getAuthToken,
       clearAuthToken,


### PR DESCRIPTION
`manifold-init` now accepts an `owner-id` attribute, and exposes that value to other web components via the `connection` interface.