### PR TITLE
update analytics events to include component analytics types

### DIFF
--- a/manifold-init-types/package.json
+++ b/manifold-init-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifoldco/manifold-init-types",
-  "version": "0.7.3",
+  "version": "0.7.3-next.0",
   "private": false,
   "description": "TypeScript types for manifold-init",
   "author": "manifoldco",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifoldco/manifold-init",
-  "version": "0.7.3",
+  "version": "0.7.3-next.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "src/",
     "react/"
   ],
-  "version": "0.7.3",
+  "version": "0.7.3-next.0",
   "description": "Manifold UI Initialization",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/v0/analytics.ts
+++ b/src/v0/analytics.ts
@@ -15,9 +15,10 @@ interface Payload {
 }
 
 /**
+ *  Metric Event Types are events that are sent for observability telemety.
  *  Based on `name`, what data should be sent?
  */
-export type EventTypes =
+export type MetricEventTypes =
   | {
       name: 'load';
       properties: {
@@ -49,16 +50,31 @@ export type EventTypes =
         rttGraphql: number;
         load: number;
       };
-    }
+    };
+
+/**
+ *  Component Analytics Event Types are events that are sent for customer analytics.
+ *  Based on `name`, what data should be sent?
+ */
+export type ComponentAnalyticsEventTypes =
   | {
       name: 'click';
       properties: Payload;
+    }
+  | {
+      name: 'component-load';
+      properties: Payload;
     };
 
-export type EventEvent = {
-  type: 'metric' | 'component-analytics';
+export type MetricEvent = {
+  type: 'metric';
 } & SharedProperties &
-  EventTypes;
+  MetricEventTypes;
+
+export type ComponentAnalyticsEvent = {
+  type: 'component-analytics';
+} & SharedProperties &
+  ComponentAnalyticsEventTypes;
 
 /**
  *  Error analytics event
@@ -80,7 +96,7 @@ export interface ErrorDetail {
   message?: string;
 }
 
-export type AnalyticsEvent = ErrorEvent | EventEvent;
+export type AnalyticsEvent = ErrorEvent | MetricEvent | ComponentAnalyticsEvent;
 
 export const endpoint = {
   local: 'http://analytics.arigato.tools/v1/events',


### PR DESCRIPTION
In an effort to add customer analytics for our web components we need to clearly distinguish observability telemetry and customer analytics. Creating seperate types and including a component-load event will allow us to use the ComponentAnalytics more widely in our components.