### PR TITLE
send load analytics event on initialization

### DIFF
--- a/src/v0/__tests__/index.spec.ts
+++ b/src/v0/__tests__/index.spec.ts
@@ -1,0 +1,36 @@
+import fetchMock from 'fetch-mock';
+import { endpoint } from '../analytics';
+import connection from '../index';
+
+describe('connection', () => {
+  describe('analytics', () => {
+    afterEach(fetchMock.restore);
+
+    it('sends an analytics component load event for a component on initialization', async () => {
+      const componentVersion = 'v0.0.0';
+      fetchMock.mock(endpoint.local, {});
+      connection({
+        env: 'local',
+        componentVersion,
+        element: document.createElement('manifold-product'),
+        getAuthToken: () => '',
+        getOwnerId: () => '',
+        clearAuthToken: () => {},
+        clientId: '123',
+      });
+      expect(fetchMock.called(endpoint.local)).toBe(true);
+      const res = fetchMock.calls()[0][1];
+      expect(res && res.body && JSON.parse(res.body.toString())).toEqual({
+        source: 'MANIFOLD-PRODUCT',
+        name: 'component-load',
+        description: 'Track component load event',
+        type: 'component-analytics',
+        properties: {
+          componentName: 'MANIFOLD-PRODUCT',
+          version: componentVersion,
+          clientId: '123', // numbers should submit as strings
+        },
+      });
+    });
+  });
+});

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -35,6 +35,13 @@ const connection = (options: {
 
   const analytics = createAnalytics({ env, element, componentVersion, clientId });
 
+  analytics.track({
+    description: 'Track component load event',
+    name: 'component-load',
+    type: 'component-analytics',
+    properties: {},
+  });
+
   return {
     getOwnerId,
     gateway: createGateway({


### PR DESCRIPTION
We want to track customer analytics over who loads the page, when, where, and why.

We could go through all of our components and manually add this event OR we could through the load event when the connection is initialized once and it will work for all components that use this version of manifold-init.

# How it works?

Do a track event over component load on initialization 

# Demo:

<img width="1574" alt="Screen Shot 2020-05-08 at 12 38 22 PM" src="https://user-images.githubusercontent.com/15069938/81422311-2d6c9980-9129-11ea-85c6-af47964c649d.png">
<img width="1579" alt="Screen Shot 2020-05-08 at 12 38 06 PM" src="https://user-images.githubusercontent.com/15069938/81422313-2e053000-9129-11ea-9512-b17bf0508b84.png">
<img width="501" alt="Screen Shot 2020-05-08 at 12 35 28 PM" src="https://user-images.githubusercontent.com/15069938/81422314-2e053000-9129-11ea-94ee-83ac96f48c81.png">
<img width="1672" alt="Screen Shot 2020-05-08 at 12 35 23 PM" src="https://user-images.githubusercontent.com/15069938/81422316-2e9dc680-9129-11ea-8681-ab67f7886c8b.png">


