### PR TITLE
send component load event when analytics component loads

### DIFF
--- a/src/components/manifold-init/manifold-init.spec.ts
+++ b/src/components/manifold-init/manifold-init.spec.ts
@@ -1,0 +1,53 @@
+import fetchMock from 'fetch-mock';
+import { newSpecPage } from '@stencil/core/testing';
+import { ManifoldInit } from './manifold-init';
+import { endpoint } from '../../v0/analytics';
+
+const ANALYTICS_ENDPOINT = endpoint.prod;
+
+interface Props {
+  clientId?: string;
+}
+
+async function setup(props: Props) {
+  const page = await newSpecPage({
+    components: [ManifoldInit],
+    html: `<div></div>`,
+  });
+
+  const component = page.doc.createElement('manifold-init');
+  component.clientId = props.clientId;
+
+  const root = page.root as HTMLDivElement;
+  root.appendChild(component);
+  await page.waitForChanges();
+
+  return { page, component };
+}
+
+describe(ManifoldInit.name, () => {
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
+  describe('component load', () => {
+    it('should send an analytics load event when it loads', async () => {
+      fetchMock.mock(ANALYTICS_ENDPOINT, {});
+      await setup({ clientId: '123' });
+      expect(fetchMock.called()).toBe(true);
+      const res = fetchMock.calls()[0][1];
+      expect(res && res.body && JSON.parse(res.body.toString())).toEqual({
+        source: 'MANIFOLD-INIT',
+        name: 'component-load',
+        description: 'Track component load event',
+        type: 'component-analytics',
+        properties: {
+          componentName: 'MANIFOLD-INIT',
+          clientId: '123',
+          version: '<@NPM_PACKAGE_VERSION@>',
+          ownerId: '',
+        },
+      });
+    });
+  });
+});

--- a/src/components/manifold-init/manifold-init.tsx
+++ b/src/components/manifold-init/manifold-init.tsx
@@ -1,5 +1,6 @@
-import { Component, Prop, Method, Event, EventEmitter, Watch } from '@stencil/core';
+import { Component, Prop, Method, Element, Event, EventEmitter, Watch } from '@stencil/core';
 import * as core from '../../core';
+import createAnalytics from '../../v0/analytics';
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
 export interface Connection extends core.Connection {}
@@ -8,6 +9,7 @@ export interface Connection extends core.Connection {}
   tag: 'manifold-init',
 })
 export class ManifoldInit {
+  @Element() el: HTMLElement;
   @Prop() env?: 'local' | 'stage' | 'prod' = 'prod';
   @Prop({ mutable: true }) authToken?: string;
   @Prop() authType?: 'manual' | 'oauth' = 'oauth';
@@ -46,6 +48,23 @@ export class ManifoldInit {
       element,
       clientId: this.clientId,
       clearAuthToken: this.clearAuthToken,
+    });
+  }
+
+  async componentWillLoad() {
+    const analytics = createAnalytics({
+      env: this.env,
+      element: this.el,
+      componentVersion: '<@NPM_PACKAGE_VERSION@>',
+      clientId: this.clientId,
+    });
+    analytics.track({
+      description: 'Track component load event',
+      name: 'component-load',
+      type: 'component-analytics',
+      properties: {
+        ownerId: this.ownerId || '',
+      },
     });
   }
 


### PR DESCRIPTION
# Change

We want to know when folks are putting the component on their sites.
Having a manifold-init load component as distinct from other components is important because it helps us understand how many pages are using our components in general rather than each component in particular.

# Demo

<img width="1334" alt="Screen Shot 2020-05-08 at 1 18 47 PM" src="https://user-images.githubusercontent.com/15069938/81425962-e681a280-912e-11ea-973d-5f76ebe09e2e.png">
<img width="1675" alt="Screen Shot 2020-05-08 at 1 18 29 PM" src="https://user-images.githubusercontent.com/15069938/81425964-e71a3900-912e-11ea-9e19-09250199c2a8.png">
